### PR TITLE
[BE] feat : calendar, record, sports 기본 기능 구현

### DIFF
--- a/server/src/main/java/com/backend/fitchallenge/domain/workout/controller/CalendarController.java
+++ b/server/src/main/java/com/backend/fitchallenge/domain/workout/controller/CalendarController.java
@@ -1,0 +1,28 @@
+package com.backend.fitchallenge.domain.workout.controller;
+
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequiredArgsConstructor
+public class CalendarController {
+    /**
+     * [캘린더 등록 방법 논의 필요]
+     * 캘린더 등록(생성)과 관련해 생각해놓은 방법은 다음과 같습니다.
+     * 1. 스케쥴러에 의해 일정 기간이 되면 자동으로 등록
+     * 2. 관리자가 직접 캘린더 등록(혹은 삭제)
+     * 3. 사용자가 기록을 등록하면 자동으로 캘린더 등록
+     *
+     * 본 컨트롤러는 2번의 경우에 필요합니다.
+     *
+     * 개인적으로는 1번이 최선의 선택지라고 생각합니다.
+     * 1번에 비해 2번은 채택 근거가 불명확하고 3번은 방법이 불명확합니다.
+     *
+     * 생각하지 못한 필요가 생길 수도 있기에 컨트롤러 틀은 만들어놨는데
+     * 추가 작업은 논의를 거친 후 필요 여부에 따라 진행할 생각입니다.
+     */
+}

--- a/server/src/main/java/com/backend/fitchallenge/domain/workout/controller/RecordController.java
+++ b/server/src/main/java/com/backend/fitchallenge/domain/workout/controller/RecordController.java
@@ -1,0 +1,53 @@
+package com.backend.fitchallenge.domain.workout.controller;
+
+import com.backend.fitchallenge.domain.workout.dto.request.RecordCreate;
+import com.backend.fitchallenge.domain.workout.dto.request.RecordUpdate;
+import com.backend.fitchallenge.domain.workout.service.RecordService;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.*;
+
+import javax.validation.Valid;
+import javax.validation.constraints.Positive;
+
+@RestController
+@RequiredArgsConstructor
+public class RecordController {
+
+    private final RecordService recordService;
+
+    /**
+     * [운동 기록 생성]
+     */
+    @PostMapping("/records")
+    public ResponseEntity<Long> create(@Valid @RequestBody RecordCreate recordCreate) {
+
+        return ResponseEntity.ok(recordService.createRecord(recordCreate));
+    }
+
+    /**
+     * [특정 달의 운동기록을 조회]
+     *
+     * (+) 1-12에 해당하는 숫자가 들어오는지 확인하는 커스텀 애너테이션 추가 예정
+     */
+    @GetMapping("/records")
+    public ResponseEntity<?> list(@Positive @RequestParam int month) {
+
+        return ResponseEntity.ok(recordService.getMonthlyRecordList(month));
+    }
+
+    /**
+     * [운동 기록 수정]
+     */
+    @PatchMapping("/records")
+    public ResponseEntity<Long> update(@Valid @RequestBody RecordUpdate recordUpdate) {
+
+        return ResponseEntity.ok(recordService.updateRecord(recordUpdate));
+    }
+
+    @DeleteMapping("/records/{record-id}")
+    public ResponseEntity<Long> delete(@PathVariable("record-id") Long recordID) {
+
+        return ResponseEntity.ok(recordService.deleteRecord(recordID));
+    }
+}

--- a/server/src/main/java/com/backend/fitchallenge/domain/workout/controller/SportsController.java
+++ b/server/src/main/java/com/backend/fitchallenge/domain/workout/controller/SportsController.java
@@ -1,0 +1,36 @@
+package com.backend.fitchallenge.domain.workout.controller;
+
+import com.backend.fitchallenge.domain.workout.dto.response.SimpleSportsResponse;
+import com.backend.fitchallenge.domain.workout.service.SportsService;
+import com.backend.fitchallenge.global.dto.response.MultiResponse;
+import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequiredArgsConstructor
+public class SportsController {
+
+    private final SportsService sportsService;
+
+    /**
+     * 전체 운동 조회
+     */
+    @GetMapping("/sports")
+    public ResponseEntity<MultiResponse<?>> list(int page, int size) {
+
+        return ResponseEntity.ok(sportsService.getSportsList(PageRequest.of(page - 1, size)));
+    }
+
+    /**
+     * 부위별 운동 조회
+     */
+    @GetMapping("/sports")
+    public ResponseEntity<MultiResponse<?>> listOfBodyPart(@RequestParam String bodyPart, int page, int size) {
+
+        return ResponseEntity.ok(sportsService.getSportsListByPart(bodyPart, PageRequest.of(page - 1, size)));
+    }
+}

--- a/server/src/main/java/com/backend/fitchallenge/domain/workout/dto/request/CalendarCreate.java
+++ b/server/src/main/java/com/backend/fitchallenge/domain/workout/dto/request/CalendarCreate.java
@@ -1,0 +1,8 @@
+package com.backend.fitchallenge.domain.workout.dto.request;
+
+import lombok.Getter;
+
+@Getter
+public class CalendarCreate {
+
+}

--- a/server/src/main/java/com/backend/fitchallenge/domain/workout/dto/request/RecordCreate.java
+++ b/server/src/main/java/com/backend/fitchallenge/domain/workout/dto/request/RecordCreate.java
@@ -1,0 +1,26 @@
+package com.backend.fitchallenge.domain.workout.dto.request;
+
+import com.fasterxml.jackson.annotation.JsonFormat;
+import lombok.Getter;
+
+import java.time.LocalTime;
+import java.util.List;
+
+@Getter
+public class RecordCreate {
+    private int year;
+    private int month;
+    private int day;
+
+    /**
+     * [String 타입의 시간 정보를 LocalTime 타입의 필드로 변환]
+     * - JSON 요청에 포함된 하단 'pattern' 형태의 문자열을 LocalTime 객체로 변환합니다.
+     * - 초는 제외할 수 있는 방법을 찾으면 추후 반영하겠습니다.
+     */
+    @JsonFormat(shape = JsonFormat.Shape.STRING, pattern = "HH:mm:ss", timezone = "Asia/Seoul")
+    LocalTime startTime;
+    @JsonFormat(shape = JsonFormat.Shape.STRING, pattern = "HH:mm:ss", timezone = "Asia/Seoul")
+    LocalTime endTime;
+
+    private List<SportsDto> sports;
+}

--- a/server/src/main/java/com/backend/fitchallenge/domain/workout/dto/request/RecordUpdate.java
+++ b/server/src/main/java/com/backend/fitchallenge/domain/workout/dto/request/RecordUpdate.java
@@ -1,0 +1,26 @@
+package com.backend.fitchallenge.domain.workout.dto.request;
+
+import com.fasterxml.jackson.annotation.JsonFormat;
+import lombok.Getter;
+
+import java.time.LocalTime;
+import java.util.List;
+
+@Getter
+public class RecordUpdate {
+    private int year;
+    private int month;
+    private int day;
+
+    /**
+     * [String 타입의 시간 정보를 LocalTime 타입의 필드로 변환]
+     * - JSON 요청에 포함된 하단 'pattern' 형태의 문자열을 LocalTime 객체로 변환합니다.
+     * - 초는 제외할 수 있는 방법을 찾으면 추후 반영하겠습니다.
+     */
+    @JsonFormat(shape = JsonFormat.Shape.STRING, pattern = "HH:mm:ss", timezone = "Asia/Seoul")
+    LocalTime startTime;
+    @JsonFormat(shape = JsonFormat.Shape.STRING, pattern = "HH:mm:ss", timezone = "Asia/Seoul")
+    LocalTime endTime;
+
+    private List<SportsDto> sports;
+}

--- a/server/src/main/java/com/backend/fitchallenge/domain/workout/dto/request/SportsDto.java
+++ b/server/src/main/java/com/backend/fitchallenge/domain/workout/dto/request/SportsDto.java
@@ -1,0 +1,19 @@
+package com.backend.fitchallenge.domain.workout.dto.request;
+
+import com.backend.fitchallenge.domain.workout.entity.Sports;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import javax.validation.constraints.NotBlank;
+
+@Getter
+@NoArgsConstructor
+public class SportsDto {
+
+    @NotBlank
+    private String name;
+
+    public Sports toEntity() {
+        return Sports.of(this.name);
+    }
+}

--- a/server/src/main/java/com/backend/fitchallenge/domain/workout/dto/request/SportsSearch.java
+++ b/server/src/main/java/com/backend/fitchallenge/domain/workout/dto/request/SportsSearch.java
@@ -1,0 +1,4 @@
+package com.backend.fitchallenge.domain.workout.dto.request;
+
+public class SportsSearch {
+}

--- a/server/src/main/java/com/backend/fitchallenge/domain/workout/dto/response/RecordResponse.java
+++ b/server/src/main/java/com/backend/fitchallenge/domain/workout/dto/response/RecordResponse.java
@@ -1,0 +1,22 @@
+package com.backend.fitchallenge.domain.workout.dto.response;
+
+import lombok.Builder;
+import lombok.Getter;
+
+import java.util.List;
+
+@Getter
+public class RecordResponse {
+    private List<SimpleRecordResponse> responses;
+
+    @Builder
+    private RecordResponse(List<SimpleRecordResponse> responses) {
+        this.responses = responses;
+    }
+
+    public static RecordResponse of(List<SimpleRecordResponse> responses) {
+        return RecordResponse.builder()
+                .responses(responses)
+                .build();
+    }
+}

--- a/server/src/main/java/com/backend/fitchallenge/domain/workout/dto/response/SimpleRecordResponse.java
+++ b/server/src/main/java/com/backend/fitchallenge/domain/workout/dto/response/SimpleRecordResponse.java
@@ -1,0 +1,33 @@
+package com.backend.fitchallenge.domain.workout.dto.response;
+
+import com.backend.fitchallenge.domain.member.dto.response.MemberResponse;
+import com.backend.fitchallenge.domain.workout.entity.Record;
+import lombok.Builder;
+import lombok.Getter;
+
+import java.time.LocalTime;
+
+@Getter
+public class SimpleRecordResponse {
+    private MemberResponse member;
+
+    private int year;
+
+    private int month;
+
+    private int day;
+
+    private LocalTime startTime;
+
+    private LocalTime endTime;
+
+    @Builder
+    public SimpleRecordResponse(Record record, MemberResponse memberResponse) {
+        this.member = memberResponse;
+        this.year = record.getYear();
+        this.month = record.getMonth();
+        this.day = record.getDay();
+        this.startTime = record.getStartTime();
+        this.endTime = record.getEndTime();
+    }
+}

--- a/server/src/main/java/com/backend/fitchallenge/domain/workout/dto/response/SimpleSportsResponse.java
+++ b/server/src/main/java/com/backend/fitchallenge/domain/workout/dto/response/SimpleSportsResponse.java
@@ -1,0 +1,26 @@
+package com.backend.fitchallenge.domain.workout.dto.response;
+
+import com.backend.fitchallenge.domain.workout.entity.Sports;
+import lombok.Builder;
+import lombok.Getter;
+
+@Getter
+public class SimpleSportsResponse {
+
+    private Long sportsId;
+
+    private String name;
+
+    @Builder
+    private SimpleSportsResponse(Long sportsId, String name) {
+        this.sportsId = sportsId;
+        this.name = name;
+    }
+
+    public static SimpleSportsResponse toResponse(Sports sports) {
+        return SimpleSportsResponse.builder()
+                .sportsId(sports.getId())
+                .name(sports.getName())
+                .build();
+    }
+}

--- a/server/src/main/java/com/backend/fitchallenge/domain/workout/entity/Calendar.java
+++ b/server/src/main/java/com/backend/fitchallenge/domain/workout/entity/Calendar.java
@@ -1,0 +1,39 @@
+package com.backend.fitchallenge.domain.workout.entity;
+
+import com.backend.fitchallenge.domain.workout.util.CalendarId;
+import lombok.AccessLevel;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import javax.persistence.*;
+import java.util.List;
+
+@Entity
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@Getter
+@IdClass(CalendarId.class)
+public class Calendar {
+
+    @Id
+    @Column(name = "YEAR")
+    private int year;
+
+    @Id
+    @Column(name = "MONTH")
+    private int month;
+
+    @Id
+    @Column(name = "DAY")
+    private int day;
+
+    @OneToMany(mappedBy = "calendar", orphanRemoval = true)
+    List<Record> recordList;
+
+    @Builder
+    public Calendar(int year, int month, int day) {
+        this.year = year;
+        this.month = month;
+        this.day = day;
+    }
+}

--- a/server/src/main/java/com/backend/fitchallenge/domain/workout/entity/Record.java
+++ b/server/src/main/java/com/backend/fitchallenge/domain/workout/entity/Record.java
@@ -1,0 +1,90 @@
+package com.backend.fitchallenge.domain.workout.entity;
+
+import com.backend.fitchallenge.domain.member.entity.Member;
+import com.backend.fitchallenge.domain.workout.dto.request.RecordCreate;
+import com.backend.fitchallenge.domain.workout.dto.request.RecordUpdate;
+import com.backend.fitchallenge.domain.workout.util.CalendarId;
+import com.backend.fitchallenge.domain.workout.util.RecordId;
+import com.backend.fitchallenge.global.audit.Auditable;
+import lombok.AccessLevel;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import javax.persistence.*;
+import java.time.LocalTime;
+import java.util.ArrayList;
+import java.util.List;
+
+@Entity
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@Getter
+@IdClass(RecordId.class)
+public class Record extends Auditable {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @Column(name = "YEAR")
+    private int year;
+
+    @Column(name = "YEAR")
+    private int month;
+
+    @Column(name = "YEAR")
+    private int day;
+
+    @Column(name = "START_TIME")
+    private LocalTime startTime;
+
+    @Column(name = "END_TIME")
+    private LocalTime endTime;
+
+    @Column(name = "MEMBER_ID")
+    private Long memberId;
+
+    @OneToMany(mappedBy = "record")
+    private List<Sports> sports = new ArrayList<>();
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumns({
+            @JoinColumn(name = "year", referencedColumnName = "year"),
+            @JoinColumn(name = "month", referencedColumnName = "month"),
+            @JoinColumn(name = "day", referencedColumnName = "day")
+    })
+    private Calendar calendar;
+
+    @Builder
+    private Record(int year, int month, int day, LocalTime startTime, LocalTime endTime, Long memberId, List<Sports> sports) {
+        this.year = year;
+        this.month = month;
+        this.day = day;
+        this.startTime = startTime;
+        this.endTime = endTime;
+        this.memberId = memberId;
+        this.sports = sports;
+    }
+
+    public static Record createRecord(RecordCreate recordCreate, Long memberId, List<Sports> sports) {
+
+        return Record.builder()
+                .year(recordCreate.getYear())
+                .month(recordCreate.getMonth())
+                .day(recordCreate.getDay())
+                .startTime(recordCreate.getStartTime())
+                .endTime(recordCreate.getEndTime())
+                .memberId(memberId)
+                .sports(sports)
+                .build();
+    }
+
+    public void updateRecord(RecordUpdate recordUpdate, List<Sports> sports) {
+        LocalTime changedStartTime = recordUpdate.getStartTime();
+        LocalTime changedEndTime = recordUpdate.getEndTime();
+
+        this.startTime = changedStartTime != null ? changedStartTime : this.startTime;
+        this.endTime = changedEndTime != null ? changedEndTime : this.endTime;
+        this.sports = sports;
+    }
+}

--- a/server/src/main/java/com/backend/fitchallenge/domain/workout/entity/Sports.java
+++ b/server/src/main/java/com/backend/fitchallenge/domain/workout/entity/Sports.java
@@ -1,0 +1,77 @@
+package com.backend.fitchallenge.domain.workout.entity;
+
+import com.backend.fitchallenge.domain.workout.dto.request.SportsDto;
+import com.backend.fitchallenge.global.audit.Auditable;
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonValue;
+import lombok.AccessLevel;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import javax.persistence.*;
+
+@Entity
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@Getter
+public class Sports extends Auditable {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    @Column(name = "SPORTS_ID", nullable = false)
+    private Long id;
+
+    @Column(nullable = false)
+    String name;
+
+    private Sports(String name) {
+        this.name = name;
+    }
+
+    public static Sports of(String name) {
+        return new Sports(name);
+    }
+
+    /**
+     * 운동부위 설정. 추후 반영 여부 결정
+     */
+    @Enumerated(value = EnumType.STRING)
+    BodyPart bodyPart;
+
+    public enum BodyPart {
+        LOWER_BODY("하체"),
+        CHEST("가슴"),
+        BACK("등"),
+        SHOULDER("어깨"),
+        ARM("팔"),
+        ABDOMINAL("복근"),
+        AEROBIC("유산소"),
+        ETC("기타");
+
+        private final String value;
+
+        BodyPart(String value) {
+            this.value = value;
+        }
+
+        /**
+         * String -> enum
+         */
+        @JsonCreator
+        public static BodyPart from(String value) {
+            for (BodyPart bodyPart : BodyPart.values()) {
+                if (bodyPart.getValue().equals(value))
+                    return bodyPart;
+            }
+            return null;
+        }
+
+        /**
+         * enum -> String
+         */
+        @JsonValue
+        public String getValue() {
+            return value;
+        }
+    }
+}

--- a/server/src/main/java/com/backend/fitchallenge/domain/workout/exception/NotRecordWriter.java
+++ b/server/src/main/java/com/backend/fitchallenge/domain/workout/exception/NotRecordWriter.java
@@ -1,0 +1,10 @@
+package com.backend.fitchallenge.domain.workout.exception;
+
+import com.backend.fitchallenge.global.error.exception.BusinessLogicException;
+import com.backend.fitchallenge.global.error.exception.ExceptionCode;
+
+public class NotRecordWriter extends BusinessLogicException {
+    public NotRecordWriter() {
+        super(ExceptionCode.NOT_RECORD_WRITER);
+    }
+}

--- a/server/src/main/java/com/backend/fitchallenge/domain/workout/exception/RecordNotFound.java
+++ b/server/src/main/java/com/backend/fitchallenge/domain/workout/exception/RecordNotFound.java
@@ -1,0 +1,10 @@
+package com.backend.fitchallenge.domain.workout.exception;
+
+import com.backend.fitchallenge.global.error.exception.BusinessLogicException;
+import com.backend.fitchallenge.global.error.exception.ExceptionCode;
+
+public class RecordNotFound extends BusinessLogicException {
+    public RecordNotFound() {
+        super(ExceptionCode.RECORD_NOT_FOUND);
+    }
+}

--- a/server/src/main/java/com/backend/fitchallenge/domain/workout/repository/CalendarRepository.java
+++ b/server/src/main/java/com/backend/fitchallenge/domain/workout/repository/CalendarRepository.java
@@ -1,0 +1,10 @@
+package com.backend.fitchallenge.domain.workout.repository;
+
+import com.backend.fitchallenge.domain.workout.entity.Calendar;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+
+public interface CalendarRepository extends JpaRepository<Calendar, Long> {
+    @Query("SELECT COUNT(*) FROM Calendar c WHERE c.year = :year AND c.month = :month")
+    Long getCount(int year, int month);
+}

--- a/server/src/main/java/com/backend/fitchallenge/domain/workout/repository/RecordRepository.java
+++ b/server/src/main/java/com/backend/fitchallenge/domain/workout/repository/RecordRepository.java
@@ -1,0 +1,20 @@
+package com.backend.fitchallenge.domain.workout.repository;
+
+import com.backend.fitchallenge.domain.workout.entity.Record;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+
+import java.util.List;
+import java.util.Optional;
+
+public interface RecordRepository extends JpaRepository<Record, Long>, RecordRepositoryCustom {
+
+    @Query("SELECT * FROM Record r WHERE r.year = :year AND r.month = :month AND r.day = :day AND r.memberId = :memberId")
+    Optional<Record> findByDateAndMemberId(int year, int month, int day, Long memberId);
+
+    @Query("SELECT r.memberId FROM Record r where r.id = :recordId")
+    Long findMemberIdByRecordId(Long recordId);
+
+    @Query("SELECT * from Record r WHERE r.memberId = :memberId AND r.month = :month")
+    List<Record> findByMemberIdAndMonth(Long memberId, int month);
+}

--- a/server/src/main/java/com/backend/fitchallenge/domain/workout/repository/RecordRepositoryCustom.java
+++ b/server/src/main/java/com/backend/fitchallenge/domain/workout/repository/RecordRepositoryCustom.java
@@ -1,0 +1,7 @@
+package com.backend.fitchallenge.domain.workout.repository;
+
+import org.springframework.stereotype.Repository;
+
+@Repository
+public interface RecordRepositoryCustom {
+}

--- a/server/src/main/java/com/backend/fitchallenge/domain/workout/repository/RecordRepositoryImpl.java
+++ b/server/src/main/java/com/backend/fitchallenge/domain/workout/repository/RecordRepositoryImpl.java
@@ -1,0 +1,14 @@
+package com.backend.fitchallenge.domain.workout.repository;
+
+import com.querydsl.jpa.impl.JPAQueryFactory;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Repository;
+
+@Repository
+@RequiredArgsConstructor
+@Slf4j
+public class RecordRepositoryImpl implements RecordRepositoryCustom{
+    private final JPAQueryFactory jpaQueryFactory;
+
+}

--- a/server/src/main/java/com/backend/fitchallenge/domain/workout/repository/SportsRepository.java
+++ b/server/src/main/java/com/backend/fitchallenge/domain/workout/repository/SportsRepository.java
@@ -1,0 +1,15 @@
+package com.backend.fitchallenge.domain.workout.repository;
+
+import com.backend.fitchallenge.domain.workout.entity.Sports;
+import org.springframework.data.domain.Page;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+
+import java.util.Arrays;
+
+public interface SportsRepository extends JpaRepository<Sports, Long> {
+    boolean existsByName(String name);
+
+    @Query("SELECT s FROM Sports s WHERE s.bodyPart = :bodyPart")
+    Page<Sports> findByBodyPart(Sports.BodyPart bodyPart);
+}

--- a/server/src/main/java/com/backend/fitchallenge/domain/workout/service/CalendarService.java
+++ b/server/src/main/java/com/backend/fitchallenge/domain/workout/service/CalendarService.java
@@ -1,0 +1,49 @@
+package com.backend.fitchallenge.domain.workout.service;
+
+import com.backend.fitchallenge.domain.workout.entity.Calendar;
+import com.backend.fitchallenge.domain.workout.repository.CalendarRepository;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Service;
+
+import java.time.LocalDateTime;
+import java.time.YearMonth;
+import java.util.ArrayList;
+import java.util.List;
+
+import static java.text.DateFormat.DEFAULT;
+
+@Service
+@RequiredArgsConstructor
+@Slf4j
+public class CalendarService {
+
+    private final CalendarRepository calendarRepository;
+
+    /**
+     * Calendar 추가하는 방식 결정 필요
+     * - 추천: 스케쥴링
+     */
+    public void addCalendar(int year, int month) {
+        if(year == DEFAULT){
+            year = LocalDateTime.now().getYear();
+            month = LocalDateTime.now().getMonth().getValue();
+        }
+
+        if(calendarRepository.getCount(year, month) == 0){
+            List<Calendar> calendarList = new ArrayList<>();
+            int lengthOfMonth = YearMonth.of(year, month).lengthOfMonth();
+
+            for(int day = 1; day <= lengthOfMonth; day++){
+                Calendar calendar = Calendar.builder()
+                        .year(year)
+                        .month(month)
+                        .day(day)
+                        .build();
+
+                calendarList.add(calendar);
+            }
+            calendarRepository.saveAll(calendarList);
+        }
+    }
+}

--- a/server/src/main/java/com/backend/fitchallenge/domain/workout/service/RecordService.java
+++ b/server/src/main/java/com/backend/fitchallenge/domain/workout/service/RecordService.java
@@ -1,0 +1,146 @@
+package com.backend.fitchallenge.domain.workout.service;
+
+import com.backend.fitchallenge.domain.member.dto.response.MemberResponse;
+import com.backend.fitchallenge.domain.member.entity.Member;
+import com.backend.fitchallenge.domain.member.exception.MemberNotExist;
+import com.backend.fitchallenge.domain.member.repository.MemberRepository;
+import com.backend.fitchallenge.domain.workout.dto.request.RecordCreate;
+import com.backend.fitchallenge.domain.workout.dto.request.RecordUpdate;
+import com.backend.fitchallenge.domain.workout.dto.request.SportsDto;
+import com.backend.fitchallenge.domain.workout.dto.response.RecordResponse;
+import com.backend.fitchallenge.domain.workout.dto.response.SimpleRecordResponse;
+import com.backend.fitchallenge.domain.workout.entity.Record;
+import com.backend.fitchallenge.domain.workout.entity.Sports;
+import com.backend.fitchallenge.domain.workout.exception.NotRecordWriter;
+import com.backend.fitchallenge.domain.workout.exception.RecordNotFound;
+import com.backend.fitchallenge.domain.workout.repository.RecordRepository;
+import com.backend.fitchallenge.global.dto.response.MultiResponse;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Optional;
+import java.util.stream.Collectors;
+
+@Service
+@RequiredArgsConstructor
+@Transactional
+@Slf4j
+public class RecordService {
+
+    private final RecordRepository recordRepository;
+    private final MemberRepository memberRepository;
+    private final SportsService sportsService;
+
+    /**
+     * [운동 기록 등록]
+     * 1. 요청을 보낸 member가 존재하는지 확인합니다.(컨트롤러 단의 커스텀 애너테이션으로 대체 예정)
+     * 2. (1) record에 입력할 sports의 목록을 생성합니다.
+     *    (2) 이 과정에서 새롭게 추가된 운동이 있다면 sportsRepository에 추가합니다.
+     * 3. record를 생성합니다.
+     */
+    public Long createRecord(RecordCreate recordCreate) {
+
+        Member member = memberRepository.findById(1L).orElseThrow(MemberNotExist::new);
+        List<Sports> sports = makeSports(recordCreate.getSports());
+
+        Record record = Record.createRecord(recordCreate, member.getId(), sports);
+
+        return recordRepository.save(record).getId();
+    }
+
+    /**
+     * [특정 유저의 월간 운동 기록 조회]
+     * 1. 요청을 보낸 member가 존재하는지 확인합니다.(컨트롤러 단의 커스텀 애너테이션으로 대체 예정)
+     * 2. memberId와 월을 사용해 record가 존재하는지 확인하고, 존재한다면 record의 목록을 반환합니다.
+     * 3. record 목록과 각각의 memberResponse를 recordResponse로 변환하고 반환합니다.
+     *
+     * (+) 챌린지 상대가 있다면 상대의 운동 기록도 조회하는 로직을 추가할 예정입니다.
+     */
+    public RecordResponse getMonthlyRecordList(int month) {
+
+        Member member = memberRepository.findById(1L).orElseThrow(MemberNotExist::new);
+        List<Record> records = recordRepository.findByMemberIdAndMonth(member.getId(), month);
+        if (records == null) {
+            throw new RecordNotFound();
+        }
+
+        List<SimpleRecordResponse> myRecordResponses = records.stream()
+                .map(record -> SimpleRecordResponse.builder()
+                        .record(record)
+                        .memberResponse(MemberResponse.of(member)
+                                ).build()).collect(Collectors.toList());
+
+        return RecordResponse.of(myRecordResponses);
+    }
+
+    /**
+     * [운동 기록 수정]
+     * 1. 요청을 보낸 member가 존재하는지 확인합니다.(컨트롤러 단의 커스텀 애너테이션으로 대체 예정)
+     * 2. 날짜(연, 월, 일)와 요청을 보낸 memberId를 통해 record가 존재하는지 확인하고, 존재한다면 해당 record를 반환합니다.
+     * 3. (1) record에 입력할 sports의 목록을 생성합니다.
+     *    (2) 이 과정에서 새롭게 추가된 운동이 있다면 sportsRepository에 추가합니다.
+     *      (sports의 등록 방식을 sports controller를 거치는 방법만으로 통일한다면 (2)는 필요하지 않습니다.)
+     * 4. sports, startTime, endTime 등의 수정사항을 record에 반영합니다.
+     */
+    public Long updateRecord(RecordUpdate recordUpdate) {
+
+        Member member = memberRepository.findById(1L).orElseThrow(MemberNotExist::new);
+        Record findRecord = recordRepository
+                .findByDateAndMemberId(recordUpdate.getYear(), recordUpdate.getMonth(), recordUpdate.getDay(), member.getId())
+                .orElseThrow(RecordNotFound::new);
+
+        List<Sports> sports = makeSports(recordUpdate.getSports());
+
+        findRecord.updateRecord(recordUpdate, sports);
+
+        return findRecord.getId();
+    }
+
+    /**
+     * [운동 기록 삭제]
+     * 1. 요청을 보낸 member가 존재하는지 확인합니다.(컨트롤러 단의 커스텀 애너테이션으로 대체 예정)
+     * 2. recordId를 통해 record가 존재하는지 확인하고 해당 record를 반환합니다.
+     * 3. 요청을 보낸 Member가 record의 writer인지 확인합니다.
+     * 4. 맞다면, record를 삭제합니다.
+     */
+    public Long deleteRecord(Long recordId) {
+
+        Member member = memberRepository.findById(1L).orElseThrow(MemberNotExist::new);
+        Record findRecord = findVerifiedRecord(recordId);
+        verifyWriter(member.getId(), findRecord);
+
+        recordRepository.delete(findRecord);
+
+        return recordId;
+    }
+
+    // record를 조회하고, 존재하면 해당 객체를 반환합니다.
+    @Transactional(readOnly = true)
+    public Record findVerifiedRecord(Long recordId) {
+        Optional<Record> optionalRecord = recordRepository.findById(recordId);
+
+        return optionalRecord.orElseThrow(RecordNotFound::new);
+    }
+
+    // 어떤 member가 record의 writer인지 확인합니다.
+    @Transactional(readOnly = true)
+    public void verifyWriter(Long memberId, Record findRecord) {
+
+        Long writerId = recordRepository.findMemberIdByRecordId(findRecord.getId());
+
+        if (!writerId.equals(memberId)) {
+            throw new NotRecordWriter();
+        }
+    }
+
+    // sportsDto 목록을 sports의 list로 변환합니다.
+    public List<Sports> makeSports(List<SportsDto> sports) {
+        return sports.stream().map(sportsService::addSports).collect(Collectors.toList());
+    }
+}

--- a/server/src/main/java/com/backend/fitchallenge/domain/workout/service/SportsService.java
+++ b/server/src/main/java/com/backend/fitchallenge/domain/workout/service/SportsService.java
@@ -1,0 +1,61 @@
+package com.backend.fitchallenge.domain.workout.service;
+
+import com.backend.fitchallenge.domain.workout.dto.request.SportsDto;
+import com.backend.fitchallenge.domain.workout.dto.response.SimpleSportsResponse;
+import com.backend.fitchallenge.domain.workout.entity.Sports;
+import com.backend.fitchallenge.domain.workout.repository.SportsRepository;
+import com.backend.fitchallenge.global.dto.response.MultiResponse;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageImpl;
+import org.springframework.data.domain.Pageable;
+import org.springframework.stereotype.Service;
+
+import java.util.stream.Collectors;
+
+@Service
+@RequiredArgsConstructor
+@Slf4j
+public class SportsService {
+
+    private final SportsRepository sportsRepository;
+
+    public Sports addSports(SportsDto sportsDto) {
+
+        Sports sports = sportsDto.toEntity();
+        if (!sportsExist(sports.getName())) {
+            sportsRepository.save(sports);
+        }
+
+        return sports;
+    }
+
+    private boolean sportsExist(String name) {
+        return sportsRepository.existsByName(name);
+    }
+
+    public MultiResponse<?> getSportsList(Pageable pageable) {
+
+        Page<SimpleSportsResponse> sportsResponses = new PageImpl<>(sportsRepository.findAll(pageable).stream()
+                .map(SimpleSportsResponse::toResponse).collect(Collectors.toList()));
+
+        return MultiResponse.of(sportsResponses);
+    }
+
+    /**
+     * [부위별 운동 조회]
+     * 1. 운동 부위 이름을 BodyPart(enum) 객체로 변환합니다.
+     * 2. 부위별 운동을 조회하고 결과값을 반환합니다.
+     */
+    public MultiResponse<?> getSportsListByPart(String bodyPart, Pageable pageable) {
+
+        Page<SimpleSportsResponse> sportsResponses = new PageImpl<>(
+                sportsRepository.findByBodyPart(Sports.BodyPart.from(bodyPart))
+                        .stream()
+                        .map(SimpleSportsResponse::toResponse)
+                        .collect(Collectors.toList()));
+
+        return MultiResponse.of(sportsResponses);
+    }
+}

--- a/server/src/main/java/com/backend/fitchallenge/domain/workout/util/CalendarId.java
+++ b/server/src/main/java/com/backend/fitchallenge/domain/workout/util/CalendarId.java
@@ -1,0 +1,19 @@
+package com.backend.fitchallenge.domain.workout.util;
+
+import lombok.AccessLevel;
+import lombok.EqualsAndHashCode;
+import lombok.NoArgsConstructor;
+
+import javax.persistence.Id;
+import java.io.Serializable;
+
+@EqualsAndHashCode
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class CalendarId implements Serializable {
+
+    private int year;
+
+    private int month;
+
+    private int day;
+}

--- a/server/src/main/java/com/backend/fitchallenge/domain/workout/util/RecordId.java
+++ b/server/src/main/java/com/backend/fitchallenge/domain/workout/util/RecordId.java
@@ -1,0 +1,38 @@
+package com.backend.fitchallenge.domain.workout.util;
+
+import lombok.AccessLevel;
+import lombok.Builder;
+import lombok.EqualsAndHashCode;
+import lombok.NoArgsConstructor;
+
+import java.io.Serializable;
+
+@EqualsAndHashCode
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class RecordId implements Serializable {
+
+    private int year;
+
+    private int month;
+
+    private int day;
+
+    private Long memberId;
+
+    @Builder
+    private RecordId(int year, int month, int day, Long memberId) {
+        this.year = year;
+        this.month = month;
+        this.day = day;
+        this.memberId = memberId;
+    }
+
+    public static RecordId of(int year, int month, int day, Long memberId) {
+        return RecordId.builder()
+                .year(year)
+                .month(month)
+                .day(day)
+                .memberId(memberId)
+                .build();
+    }
+}


### PR DESCRIPTION
calendar, record, sports의 기본 구조와 record의 CRUD, sports의 조회 기능을 구현했습니다.

1. 현재는 임의로 workout이라는 한 디렉토리에 몰아놨지만 추후 조정 가능합니다.
2. repository단의 메서드를 Querydsl을 사용한 형태로 바꿀 예정입니다.
3. calender와 sports의 등록 기능을 추후 추가할 예정입니다.