### PR TITLE
feat : oauth2 멤버 기본정보 설정 업데이트

### DIFF
--- a/server/src/main/java/com/backend/fitchallenge/domain/challenge/dto/response/ChallengeResponse.java
+++ b/server/src/main/java/com/backend/fitchallenge/domain/challenge/dto/response/ChallengeResponse.java
@@ -15,19 +15,21 @@ public class ChallengeResponse {
 
     private Long applicantId;
     private String applicantName;
-    private ProfileImage applicantImage;
+//    private ProfileImage applicantImage;
+    private String applicantImage;
     private Integer applicantHeight;
     private Integer applicantWeight;
 
     private Long counterpartId;
     private String counterpartName;
-    private ProfileImage counterpartImage;
+//    private ProfileImage counterpartImage;
+    private String counterpartImage;
     private Integer counterpartHeight;
     private Integer counterpartWeight;
 
 @Builder
-    public ChallengeResponse(Long applicantId, String applicantName, ProfileImage applicantImage, Integer applicantHeight, Integer applicantWeight,
-                             Long counterpartId, String counterpartName, ProfileImage counterpartImage, Integer counterpartHeight, Integer counterpartWeight) {
+    public ChallengeResponse(Long applicantId, String applicantName, String applicantImage, Integer applicantHeight, Integer applicantWeight,
+                             Long counterpartId, String counterpartName, String counterpartImage, Integer counterpartHeight, Integer counterpartWeight) {
         this.applicantId = applicantId;
         this.applicantName = applicantName;
         this.applicantImage = applicantImage;
@@ -44,16 +46,14 @@ public class ChallengeResponse {
         return ChallengeResponse.builder()
                 .applicantId(applicant.getId())
                 .applicantName(applicant.getUsername())
-                .applicantImage(applicant.getProfileImage())
+                .applicantImage(applicant.getProfileImage().getPath())
                 .applicantHeight(applicant.getHeight())
                 .applicantWeight(applicant.getWeight())
                 .counterpartId(counterpart.getId())
                 .counterpartName(counterpart.getUsername())
-                .counterpartImage(counterpart.getProfileImage())
+                .counterpartImage(counterpart.getProfileImage().getPath())
                 .counterpartHeight(counterpart.getHeight())
                 .counterpartWeight(counterpart.getWeight())
                 .build();
     }
-
-
 }

--- a/server/src/main/java/com/backend/fitchallenge/domain/member/controller/MemberController.java
+++ b/server/src/main/java/com/backend/fitchallenge/domain/member/controller/MemberController.java
@@ -40,7 +40,7 @@ public class MemberController {
     }
 
     //회원 정보 수정
-    @PatchMapping("/myPage")
+    @PostMapping("/myPage")
     public ResponseEntity update(@AuthMember MemberDetails memberDetails,
                                  MemberUpdateVO memberUpdateVO){ //todo. requestbody 때기 - checked
 

--- a/server/src/main/java/com/backend/fitchallenge/domain/member/dto/request/MemberCreate.java
+++ b/server/src/main/java/com/backend/fitchallenge/domain/member/dto/request/MemberCreate.java
@@ -43,6 +43,8 @@ public class MemberCreate {
     public Member toEntity(){
         return Member.createBuilder()
                 .email(email)
+                .username(username)
+                .password(password)
                 .build();
     }
 }

--- a/server/src/main/java/com/backend/fitchallenge/domain/member/entity/Member.java
+++ b/server/src/main/java/com/backend/fitchallenge/domain/member/entity/Member.java
@@ -25,41 +25,40 @@ public class Member extends Auditable {
 
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)
-    @Column(name = "MEMBER_ID", nullable = false, updatable = false)
+    @Column(nullable = false, updatable = false)
     private Long id;
 
-    @Column(name = "EMAIL", nullable = false, updatable = false, unique = true)
+    @Column(nullable = false, updatable = false, unique = true)
     private String email;
 
-    @Column(name = "PASSWORD")
+    @Column
     private String password;
 
-    @Column(name = "USERNAME")
+    @Column
     private String username;
 
-
-    @Column(name = "GENDER")
+    @Column
     private String gender;
 
-    @Column(name = "JOB")
+    @Column
     private String job;
 
-    @Column(name = "ADDRESS")
+    @Column
     private String address;
 
-    @Column(name = "AGE")
+    @Column
     private Integer age;
 
-    @Column(name = "HEIGHT")
+    @Column
     private Integer height;
 
-    @Column(name = "WEIGHT")
+    @Column
     private Integer weight;
 
-    @Column(name = "SPLIT")
+    @Column
     private Integer split;
 
-    @Column(name = "PERIOD")
+    @Column
     private Integer period;
 
     @Enumerated(EnumType.STRING)
@@ -109,6 +108,10 @@ public class Member extends Auditable {
                 .build();
         this.split = memberUpdateVO.getSplit() == null ? this.split : memberUpdateVO.getSplit();
         this.period = memberUpdateVO.getPeriod() == null ? this.period : memberUpdateVO.getPeriod();
+    }
+
+    public void oauth2Update(ProfileImage profileImage){
+        this.profileImage = profileImage;
     }
 
 

--- a/server/src/main/java/com/backend/fitchallenge/domain/member/service/MemberService.java
+++ b/server/src/main/java/com/backend/fitchallenge/domain/member/service/MemberService.java
@@ -48,7 +48,8 @@ public class MemberService {
 
         isMemberExist(memberCreate.getEmail());
 
-        ProfileImage profileImage = ProfileImage.createWithPath("https://pre-project-bucket-seb40-017.s3.ap-northeast-2.amazonaws.com/00398f65-51c3-4c1d-baac-38070910c5b3.png");
+        ProfileImage profileImage = ProfileImage.createWithPath(
+                "https://pre-project-bucket-seb40-017.s3.ap-northeast-2.amazonaws.com/00398f65-51c3-4c1d-baac-38070910c5b3.png");
         Member member = memberCreate.toEntity(passwordEncoder, profileImage);
         profileImage.setMember(member);
 

--- a/server/src/main/java/com/backend/fitchallenge/domain/post/controller/PostController.java
+++ b/server/src/main/java/com/backend/fitchallenge/domain/post/controller/PostController.java
@@ -91,7 +91,7 @@ public class PostController {
      *
      * @param postUpdate    게시물 수정 요청 정보
      */
-    @PatchMapping("/{id}")
+    @PostMapping("/{id}")
     public ResponseEntity<?> update(
             @AuthMember MemberDetails memberDetails, @PathVariable Long id,
             PostUpdateVO postUpdate) {

--- a/server/src/main/java/com/backend/fitchallenge/domain/question/controller/QuestionController.java
+++ b/server/src/main/java/com/backend/fitchallenge/domain/question/controller/QuestionController.java
@@ -63,7 +63,7 @@ public class QuestionController {
         return ResponseEntity.ok(questionService.getQuestionList(pageable, questionSearch));
     }
 
-    @PatchMapping("/questions/{id}")
+    @PostMapping("/questions/{id}")
     public ResponseEntity<Long> update(@AuthMember MemberDetails memberDetails,
                                        @PathVariable Long id,
                                        QuestionUpdateVO questionUpdateVO) {

--- a/server/src/main/java/com/backend/fitchallenge/domain/record/controller/RecordController.java
+++ b/server/src/main/java/com/backend/fitchallenge/domain/record/controller/RecordController.java
@@ -46,7 +46,7 @@ public class RecordController {
         return ResponseEntity.ok(recordService.getMonthlyRecordList(memberDetails.getMemberId(), month));
     }
 
-    @PatchMapping("/records/{record-id}")
+    @PostMapping("/records/{record-id}")
     public ResponseEntity<Long> update(@AuthMember MemberDetails memberDetails,
                                        @PathVariable("record-id") Long recordId,
                                        RecordUpdateVO recordUpdateVO) {

--- a/server/src/main/java/com/backend/fitchallenge/global/batch/scheduler/JobScheduler.java
+++ b/server/src/main/java/com/backend/fitchallenge/global/batch/scheduler/JobScheduler.java
@@ -23,7 +23,7 @@ public class JobScheduler {
     private final JobLauncher jobLauncher;
     private final BatchConfig batchConfig;
 
-    @Scheduled(cron="* */5 * * * *")
+    @Scheduled(cron="0 */5 * * * *")
     public void runJob(){
 
         Map<String, JobParameter> confMap = new HashMap<>();

--- a/server/src/main/java/com/backend/fitchallenge/global/security/userdetails/OAuth2DetailsService.java
+++ b/server/src/main/java/com/backend/fitchallenge/global/security/userdetails/OAuth2DetailsService.java
@@ -3,6 +3,7 @@ package com.backend.fitchallenge.global.security.userdetails;
 
 import com.backend.fitchallenge.domain.member.dto.request.MemberCreate;
 import com.backend.fitchallenge.domain.member.entity.Member;
+import com.backend.fitchallenge.domain.member.entity.ProfileImage;
 import com.backend.fitchallenge.domain.member.exception.MemberNotExist;
 import com.backend.fitchallenge.domain.member.repository.MemberRepository;
 import com.backend.fitchallenge.global.security.oauth2.GoogleUserInfo;
@@ -17,6 +18,7 @@ import org.springframework.security.oauth2.core.user.OAuth2User;
 import org.springframework.stereotype.Component;
 
 import java.util.Optional;
+import java.util.UUID;
 
 /**
  * OAuth2로 부터 가져온 유저 정보로 MemberDetail을 생성하는 클래스
@@ -59,11 +61,18 @@ public class OAuth2DetailsService implements OAuth2UserService<OAuth2UserRequest
 
 
     private void saveMember(String email, String name) {
+
+        ProfileImage profileImage = ProfileImage.createWithPath(
+                "https://pre-project-bucket-seb40-017.s3.ap-northeast-2.amazonaws.com/00398f65-51c3-4c1d-baac-38070910c5b3.png");
         MemberCreate memberCreate = MemberCreate.builder()
                 .email(email)
                 .username(name)
+                .password(UUID.randomUUID().toString())
                 .build();
+
         Member member = memberCreate.toEntity();
+        member.oauth2Update(profileImage);
+        profileImage.setMember(member);
 
         memberRepository.save(member);
     }


### PR DESCRIPTION
1. Oauth2 최초 회원가입시 로직에 부가기능 추가
-> 기본 프로필 이미지 설정, UUID 패스워드 기입.

2. VO관련 메서드 맵핑 수정
-> member, record, post, question 의 update메서드 'PatchMapping'에서 'PostMapping'

3. Cron 수정
-> * */5 * * * * 에서 0 */5 * * * * 

4. member 엔티티 Column 네임 제거

5. challengeResponse 필드 profileImage수정
-> field타입 profileImage -> String